### PR TITLE
[Task-1] Add business equipment request commands

### DIFF
--- a/internal/app/commands/business/commander.go
+++ b/internal/app/commands/business/commander.go
@@ -1,0 +1,46 @@
+package business
+
+import (
+	"github.com/ozonmp/omp-bot/internal/app/commands/business/equipment_request"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+type Commander interface {
+	HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath)
+	HandleCommand(message *tgbotapi.Message, commandPath path.CommandPath)
+}
+
+type BusinessCommander struct {
+	bot                       *tgbotapi.BotAPI
+	equipmentRequestCommander Commander
+}
+
+func NewBusinessCommander(
+	bot *tgbotapi.BotAPI,
+) *BusinessCommander {
+	return &BusinessCommander{
+		bot:                       bot,
+		equipmentRequestCommander: equipment_request.NewEquipmentRequestCommander(bot),
+	}
+}
+
+func (c *BusinessCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	switch callbackPath.Subdomain {
+	case "equipmentRequest":
+		c.equipmentRequestCommander.HandleCallback(callback, callbackPath)
+	default:
+		log.Printf("BusinessCommander.HandleCallback: unknown subdomain - %s", callbackPath.Subdomain)
+	}
+}
+
+func (c *BusinessCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+	switch commandPath.Subdomain {
+	case "equipmentRequest":
+		c.equipmentRequestCommander.HandleCommand(msg, commandPath)
+	default:
+		log.Printf("BusinessCommander.HandleCommand: unknown subdomain - %s", commandPath.Subdomain)
+	}
+}

--- a/internal/app/commands/business/equipment_request/callback_list.go
+++ b/internal/app/commands/business/equipment_request/callback_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (c *EquipmentRequestCommander) CallbackList(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
-	parsedData := pagination.CallbackListData{}
+	var parsedData pagination.CallbackListData
 	err := json.Unmarshal([]byte(callbackPath.CallbackData), &parsedData)
 	if err != nil {
 		log.Printf("EquipmentRequestCommander.CallbackList: "+

--- a/internal/app/commands/business/equipment_request/callback_list.go
+++ b/internal/app/commands/business/equipment_request/callback_list.go
@@ -1,0 +1,31 @@
+package equipment_request
+
+import (
+	"encoding/json"
+	"github.com/ozonmp/omp-bot/internal/app/commands/business/equipment_request/pagination"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+func (c *EquipmentRequestCommander) CallbackList(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	parsedData := pagination.CallbackListData{}
+	err := json.Unmarshal([]byte(callbackPath.CallbackData), &parsedData)
+	if err != nil {
+		log.Printf("EquipmentRequestCommander.CallbackList: "+
+			"error reading json data for type CallbackListData from "+
+			"input string %v - %v", callbackPath.CallbackData, err)
+		msg := tgbotapi.NewMessage(callback.Message.Chat.ID, "Unable to get list of equipment requests for selected page")
+		c.sendMessage(msg)
+		return
+	}
+
+	listPagination := pagination.NewListPagination(
+		c.equipmentRequestService,
+		pagination.ListPerPageDefault,
+		parsedData)
+
+	msg := listPagination.GetMessageWithList(callback.Message.Chat.ID)
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/callback_list.go
+++ b/internal/app/commands/business/equipment_request/callback_list.go
@@ -16,8 +16,7 @@ func (c *EquipmentRequestCommander) CallbackList(callback *tgbotapi.CallbackQuer
 		log.Printf("EquipmentRequestCommander.CallbackList: "+
 			"error reading json data for type CallbackListData from "+
 			"input string %v - %v", callbackPath.CallbackData, err)
-		msg := tgbotapi.NewMessage(callback.Message.Chat.ID, "Unable to get list of equipment requests for selected page")
-		c.sendMessage(msg)
+		c.sendMessage(callback.Message.Chat.ID, "Unable to get list of equipment requests for selected page")
 		return
 	}
 
@@ -26,6 +25,6 @@ func (c *EquipmentRequestCommander) CallbackList(callback *tgbotapi.CallbackQuer
 		pagination.ListPerPageDefault,
 		parsedData)
 
-	msg := listPagination.GetMessageWithList(callback.Message.Chat.ID)
-	c.sendMessage(msg)
+	msg, buttons := listPagination.GetMessageWithButtons()
+	c.sendMessageWithButtons(callback.Message.Chat.ID, msg, buttons)
 }

--- a/internal/app/commands/business/equipment_request/command_default.go
+++ b/internal/app/commands/business/equipment_request/command_default.go
@@ -9,6 +9,5 @@ import (
 
 func (c *EquipmentRequestCommander) Default(inputMessage *tgbotapi.Message) {
 	log.Printf("[%s] %s", inputMessage.From.UserName, inputMessage.Text)
-	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("You wrote: %s"+inputMessage.Text))
-	c.sendMessage(msg)
+	c.sendMessage(inputMessage.Chat.ID, fmt.Sprintf("You wrote: %s", inputMessage.Text))
 }

--- a/internal/app/commands/business/equipment_request/command_default.go
+++ b/internal/app/commands/business/equipment_request/command_default.go
@@ -1,0 +1,14 @@
+package equipment_request
+
+import (
+	"fmt"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *EquipmentRequestCommander) Default(inputMessage *tgbotapi.Message) {
+	log.Printf("[%s] %s", inputMessage.From.UserName, inputMessage.Text)
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("You wrote: %s"+inputMessage.Text))
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/command_edit.go
+++ b/internal/app/commands/business/equipment_request/command_edit.go
@@ -17,16 +17,14 @@ func (c *EquipmentRequestCommander) Edit(inputMessage *tgbotapi.Message) {
 	updateParts := strings.SplitN(args, " ", 2)
 	if len(updateParts) != 2 {
 		log.Printf("invalid number of arguments %s", args)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid number of arguments: it should be id (positive integer number) and json with equipment request data")
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, "Invalid number of arguments: it should be id (positive integer number) and json with equipment request data")
 		return
 	}
 
 	idx, err := strconv.ParseUint(updateParts[0], 10, 64)
 	if err != nil {
 		log.Printf("invalid format of argument id %s: %v", args, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
 		return
 	}
 
@@ -34,21 +32,18 @@ func (c *EquipmentRequestCommander) Edit(inputMessage *tgbotapi.Message) {
 	err = json.Unmarshal([]byte(updateParts[1]), &updateData)
 	if err != nil {
 		log.Printf("invalid format of equipmen request json entity %s: %v", args, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of equipment request json entity")
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, "Invalid format of equipment request json entity")
 		return
 	}
 
 	err = c.equipmentRequestService.Update(idx, updateData)
 	if err != nil {
 		log.Printf("fail to update equipment request with id %d: %v", idx, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to update equipment request with id: %d", idx))
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to update equipment request with id: %d", idx))
 		return
 	}
 
 	resultMsg := fmt.Sprintf("Equipment request with id %d has been updated", idx)
 
-	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, resultMsg)
-	c.sendMessage(msg)
+	c.sendMessage(inputMessage.Chat.ID, resultMsg)
 }

--- a/internal/app/commands/business/equipment_request/command_edit.go
+++ b/internal/app/commands/business/equipment_request/command_edit.go
@@ -28,7 +28,7 @@ func (c *EquipmentRequestCommander) Edit(inputMessage *tgbotapi.Message) {
 		return
 	}
 
-	updateData := business.EquipmentRequest{}
+	var updateData business.EquipmentRequest
 	err = json.Unmarshal([]byte(updateParts[1]), &updateData)
 	if err != nil {
 		log.Printf("invalid format of equipmen request json entity %s: %v", args, err)

--- a/internal/app/commands/business/equipment_request/command_edit.go
+++ b/internal/app/commands/business/equipment_request/command_edit.go
@@ -1,0 +1,54 @@
+package equipment_request
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ozonmp/omp-bot/internal/model/business"
+	"log"
+	"strconv"
+	"strings"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *EquipmentRequestCommander) Edit(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+
+	updateParts := strings.SplitN(args, " ", 2)
+	if len(updateParts) != 2 {
+		log.Printf("invalid number of arguments %s", args)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid number of arguments: it should be id (positive integer number) and json with equipment request data")
+		c.sendMessage(msg)
+		return
+	}
+
+	idx, err := strconv.ParseUint(updateParts[0], 10, 64)
+	if err != nil {
+		log.Printf("invalid format of argument id %s: %v", args, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
+		c.sendMessage(msg)
+		return
+	}
+
+	updateData := business.EquipmentRequest{}
+	err = json.Unmarshal([]byte(updateParts[1]), &updateData)
+	if err != nil {
+		log.Printf("invalid format of equipmen request json entity %s: %v", args, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of equipment request json entity")
+		c.sendMessage(msg)
+		return
+	}
+
+	err = c.equipmentRequestService.Update(idx, updateData)
+	if err != nil {
+		log.Printf("fail to update equipment request with id %d: %v", idx, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to update equipment request with id: %d", idx))
+		c.sendMessage(msg)
+		return
+	}
+
+	resultMsg := fmt.Sprintf("Equipment request with id %d has been updated", idx)
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, resultMsg)
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/command_get.go
+++ b/internal/app/commands/business/equipment_request/command_get.go
@@ -14,19 +14,16 @@ func (c *EquipmentRequestCommander) Get(inputMessage *tgbotapi.Message) {
 	idx, err := strconv.ParseUint(args, 10, 64)
 	if err != nil {
 		log.Printf("invalid format of argument id %s: %v", args, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
 		return
 	}
 
 	equipmentRequest, err := c.equipmentRequestService.Get(idx)
 	if err != nil {
 		log.Printf("fail to get equipment request with id %d: %v", idx, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to get equipment request with id: %d", idx))
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to get equipment request with id: %d", idx))
 		return
 	}
 
-	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, equipmentRequest.String())
-	c.sendMessage(msg)
+	c.sendMessage(inputMessage.Chat.ID, equipmentRequest.String())
 }

--- a/internal/app/commands/business/equipment_request/command_get.go
+++ b/internal/app/commands/business/equipment_request/command_get.go
@@ -1,0 +1,32 @@
+package equipment_request
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *EquipmentRequestCommander) Get(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+
+	idx, err := strconv.ParseUint(args, 10, 64)
+	if err != nil {
+		log.Printf("invalid format of argument id %s: %v", args, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
+		c.sendMessage(msg)
+		return
+	}
+
+	equipmentRequest, err := c.equipmentRequestService.Get(idx)
+	if err != nil {
+		log.Printf("fail to get equipment request with id %d: %v", idx, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to get equipment request with id: %d", idx))
+		c.sendMessage(msg)
+		return
+	}
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, equipmentRequest.String())
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/command_help.go
+++ b/internal/app/commands/business/equipment_request/command_help.go
@@ -1,0 +1,16 @@
+package equipment_request
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *EquipmentRequestCommander) Help(inputMessage *tgbotapi.Message) {
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "/help__business__equipmentRequest - help\n"+
+		"/list__business__equipmentRequest - list of all equipment requests\n"+
+		"/get__business__equipmentRequest {id} - get one equipment request by id\n"+
+		"/new__business__equipmentRequest {json} - create a new one equipment request by json\n"+
+		"/edit__business__equipmentRequest {id} {json} - update existing equipment request by id\n"+
+		"/remove__business__equipmentRequest {id} - remove one equipment request by id")
+
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/command_help.go
+++ b/internal/app/commands/business/equipment_request/command_help.go
@@ -5,12 +5,10 @@ import (
 )
 
 func (c *EquipmentRequestCommander) Help(inputMessage *tgbotapi.Message) {
-	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "/help__business__equipmentRequest - help\n"+
+	c.sendMessage(inputMessage.Chat.ID, "/help__business__equipmentRequest - help\n"+
 		"/list__business__equipmentRequest - list of all equipment requests\n"+
 		"/get__business__equipmentRequest {id} - get one equipment request by id\n"+
 		"/new__business__equipmentRequest {json} - create a new one equipment request by json\n"+
 		"/edit__business__equipmentRequest {id} {json} - update existing equipment request by id\n"+
 		"/remove__business__equipmentRequest {id} - remove one equipment request by id")
-
-	c.sendMessage(msg)
 }

--- a/internal/app/commands/business/equipment_request/command_list.go
+++ b/internal/app/commands/business/equipment_request/command_list.go
@@ -11,6 +11,6 @@ func (c *EquipmentRequestCommander) List(inputMessage *tgbotapi.Message) {
 		pagination.ListPerPageDefault,
 		pagination.CallbackListData{Page: 0})
 
-	msg := listPagination.GetMessageWithList(inputMessage.Chat.ID)
-	c.sendMessage(msg)
+	msg, buttons := listPagination.GetMessageWithButtons()
+	c.sendMessageWithButtons(inputMessage.Chat.ID, msg, buttons)
 }

--- a/internal/app/commands/business/equipment_request/command_list.go
+++ b/internal/app/commands/business/equipment_request/command_list.go
@@ -1,0 +1,16 @@
+package equipment_request
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/commands/business/equipment_request/pagination"
+)
+
+func (c *EquipmentRequestCommander) List(inputMessage *tgbotapi.Message) {
+	listPagination := pagination.NewListPagination(
+		c.equipmentRequestService,
+		pagination.ListPerPageDefault,
+		pagination.CallbackListData{Page: 0})
+
+	msg := listPagination.GetMessageWithList(inputMessage.Chat.ID)
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/command_new.go
+++ b/internal/app/commands/business/equipment_request/command_new.go
@@ -15,19 +15,16 @@ func (c *EquipmentRequestCommander) New(inputMessage *tgbotapi.Message) {
 	err := json.Unmarshal([]byte(args), &parsedData)
 	if err != nil {
 		log.Printf("invalid format of equipmen request json entity %s: %v", args, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of equipment request json entity")
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, "Invalid format of equipment request json entity")
 		return
 	}
 
 	insertedId, err := c.equipmentRequestService.Create(parsedData)
 	if err != nil {
 		log.Printf("fail to create equipment request with:%v, %v", parsedData, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to create equipment request with data: %v", parsedData))
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to create equipment request with data: %v", parsedData))
 		return
 	}
 
-	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Equipment request with id %d has been created", insertedId))
-	c.sendMessage(msg)
+	c.sendMessage(inputMessage.Chat.ID, fmt.Sprintf("Equipment request with id %d has been created", insertedId))
 }

--- a/internal/app/commands/business/equipment_request/command_new.go
+++ b/internal/app/commands/business/equipment_request/command_new.go
@@ -11,7 +11,7 @@ import (
 func (c *EquipmentRequestCommander) New(inputMessage *tgbotapi.Message) {
 	args := inputMessage.CommandArguments()
 
-	parsedData := business.EquipmentRequest{}
+	var parsedData business.EquipmentRequest
 	err := json.Unmarshal([]byte(args), &parsedData)
 	if err != nil {
 		log.Printf("invalid format of equipmen request json entity %s: %v", args, err)

--- a/internal/app/commands/business/equipment_request/command_new.go
+++ b/internal/app/commands/business/equipment_request/command_new.go
@@ -1,0 +1,33 @@
+package equipment_request
+
+import (
+	"encoding/json"
+	"fmt"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/model/business"
+	"log"
+)
+
+func (c *EquipmentRequestCommander) New(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+
+	parsedData := business.EquipmentRequest{}
+	err := json.Unmarshal([]byte(args), &parsedData)
+	if err != nil {
+		log.Printf("invalid format of equipmen request json entity %s: %v", args, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of equipment request json entity")
+		c.sendMessage(msg)
+		return
+	}
+
+	insertedId, err := c.equipmentRequestService.Create(parsedData)
+	if err != nil {
+		log.Printf("fail to create equipment request with:%v, %v", parsedData, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to create equipment request with data: %v", parsedData))
+		c.sendMessage(msg)
+		return
+	}
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Equipment request with id %d has been created", insertedId))
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/command_remove.go
+++ b/internal/app/commands/business/equipment_request/command_remove.go
@@ -14,16 +14,14 @@ func (c *EquipmentRequestCommander) Remove(inputMessage *tgbotapi.Message) {
 	idx, err := strconv.ParseUint(args, 10, 64)
 	if err != nil {
 		log.Printf("invalid format of argument id %s: %v", args, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
 		return
 	}
 
 	result, err := c.equipmentRequestService.Remove(idx)
 	if err != nil {
 		log.Printf("fail to remove equipment request with id %d: %v", idx, err)
-		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to remove equipment request with id: %d", idx))
-		c.sendMessage(msg)
+		c.sendMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to remove equipment request with id: %d", idx))
 		return
 	}
 
@@ -33,6 +31,5 @@ func (c *EquipmentRequestCommander) Remove(inputMessage *tgbotapi.Message) {
 		resultMsg = fmt.Sprintf("Equipment request with id %d has not been deleted", idx)
 	}
 
-	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, resultMsg)
-	c.sendMessage(msg)
+	c.sendMessage(inputMessage.Chat.ID, resultMsg)
 }

--- a/internal/app/commands/business/equipment_request/command_remove.go
+++ b/internal/app/commands/business/equipment_request/command_remove.go
@@ -1,0 +1,38 @@
+package equipment_request
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *EquipmentRequestCommander) Remove(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+
+	idx, err := strconv.ParseUint(args, 10, 64)
+	if err != nil {
+		log.Printf("invalid format of argument id %s: %v", args, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Invalid format of argument id: it should be positive integer number")
+		c.sendMessage(msg)
+		return
+	}
+
+	result, err := c.equipmentRequestService.Remove(idx)
+	if err != nil {
+		log.Printf("fail to remove equipment request with id %d: %v", idx, err)
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Fail to remove equipment request with id: %d", idx))
+		c.sendMessage(msg)
+		return
+	}
+
+	resultMsg := fmt.Sprintf("Equipment request with id %d has been deleted", idx)
+
+	if result == false {
+		resultMsg = fmt.Sprintf("Equipment request with id %d has not been deleted", idx)
+	}
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, resultMsg)
+	c.sendMessage(msg)
+}

--- a/internal/app/commands/business/equipment_request/commander.go
+++ b/internal/app/commands/business/equipment_request/commander.go
@@ -24,7 +24,21 @@ func NewEquipmentRequestCommander(
 	}
 }
 
-func (c *EquipmentRequestCommander) sendMessage(msg tgbotapi.MessageConfig) {
+func (c *EquipmentRequestCommander) sendMessageWithButtons(chatId int64, info string, buttons []tgbotapi.InlineKeyboardButton) {
+	msg := tgbotapi.NewMessage(chatId, info)
+
+	if buttons != nil && len(buttons) > 0 {
+		msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(buttons)
+	}
+
+	_, err := c.bot.Send(msg)
+	if err != nil {
+		log.Printf("EquipmentRequestCommander.sendMessageWithButtons: error sending reply message to chat - %v", err)
+	}
+}
+
+func (c *EquipmentRequestCommander) sendMessage(chatId int64, info string) {
+	msg := tgbotapi.NewMessage(chatId, info)
 	_, err := c.bot.Send(msg)
 	if err != nil {
 		log.Printf("EquipmentRequestCommander.sendMessage: error sending reply message to chat - %v", err)

--- a/internal/app/commands/business/equipment_request/commander.go
+++ b/internal/app/commands/business/equipment_request/commander.go
@@ -1,0 +1,60 @@
+package equipment_request
+
+import (
+	"github.com/ozonmp/omp-bot/internal/service/business/equipment_request"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+type EquipmentRequestCommander struct {
+	bot                     *tgbotapi.BotAPI
+	equipmentRequestService equipment_request.EquipmentRequestService
+}
+
+func NewEquipmentRequestCommander(
+	bot *tgbotapi.BotAPI,
+) *EquipmentRequestCommander {
+	equipmentRequestService := equipment_request.NewDummyEquipmentRequestService()
+
+	return &EquipmentRequestCommander{
+		bot:                     bot,
+		equipmentRequestService: equipmentRequestService,
+	}
+}
+
+func (c *EquipmentRequestCommander) sendMessage(msg tgbotapi.MessageConfig) {
+	_, err := c.bot.Send(msg)
+	if err != nil {
+		log.Printf("EquipmentRequestCommander.sendMessage: error sending reply message to chat - %v", err)
+	}
+}
+
+func (c *EquipmentRequestCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	switch callbackPath.CallbackName {
+	case "list":
+		c.CallbackList(callback, callbackPath)
+	default:
+		log.Printf("EquipmentRequestCommander.HandleCallback: unknown callback name: %s", callbackPath.CallbackName)
+	}
+}
+
+func (c *EquipmentRequestCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+	switch commandPath.CommandName {
+	case "help":
+		c.Help(msg)
+	case "list":
+		c.List(msg)
+	case "get":
+		c.Get(msg)
+	case "remove":
+		c.Remove(msg)
+	case "new":
+		c.New(msg)
+	case "edit":
+		c.Edit(msg)
+	default:
+		c.Default(msg)
+	}
+}

--- a/internal/app/commands/business/equipment_request/pagination/models.go
+++ b/internal/app/commands/business/equipment_request/pagination/models.go
@@ -1,0 +1,5 @@
+package pagination
+
+type CallbackListData struct {
+	Page uint64 `json:"page"`
+}

--- a/internal/app/commands/business/equipment_request/pagination/pagination.go
+++ b/internal/app/commands/business/equipment_request/pagination/pagination.go
@@ -32,29 +32,26 @@ func NewListPagination(
 	}
 }
 
-func (l *ListPagination) GetMessageWithList(chatId int64) (msg tgbotapi.MessageConfig) {
+func (l *ListPagination) GetMessageWithButtons() (string, []tgbotapi.InlineKeyboardButton) {
 	outputMsgText := "Here all the equipment requests: \n\n"
 
 	currentPage := l.callbackListData.Page
 	count := l.equipmentRequestService.Count()
 
 	if count == 0 {
-		outputMsgText = "List with equipment requests is empty"
-		return tgbotapi.NewMessage(chatId, outputMsgText)
+		return "List with equipment requests is empty", nil
 	}
 
 	equipmentRequests, err := l.equipmentRequestService.List(currentPage, l.perPage)
 	if err != nil {
 		log.Printf("failed to get list of equipment requests in page %d with limit %d: %v", currentPage, l.perPage, err)
-		return tgbotapi.NewMessage(chatId, "Unable to get list of equipment requests for selected page")
+		return "Unable to get list of equipment requests for selected page", nil
 	}
 
 	for _, eq := range equipmentRequests {
 		outputMsgText += eq.String()
 		outputMsgText += "\n"
 	}
-
-	msg = tgbotapi.NewMessage(chatId, outputMsgText)
 
 	var buttons []tgbotapi.InlineKeyboardButton
 
@@ -88,9 +85,5 @@ func (l *ListPagination) GetMessageWithList(chatId int64) (msg tgbotapi.MessageC
 		buttons = append(buttons, tgbotapi.NewInlineKeyboardButtonData("Next page", pageNext.String()))
 	}
 
-	if len(buttons) > 0 {
-		msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(buttons)
-	}
-
-	return msg
+	return outputMsgText, buttons
 }

--- a/internal/app/commands/business/equipment_request/pagination/pagination.go
+++ b/internal/app/commands/business/equipment_request/pagination/pagination.go
@@ -1,0 +1,96 @@
+package pagination
+
+import (
+	"encoding/json"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+	"github.com/ozonmp/omp-bot/internal/service/business/equipment_request"
+	"log"
+)
+
+type Pagination interface {
+	GetList(chatId int64) (msg tgbotapi.MessageConfig)
+}
+
+const ListPerPageDefault = 2
+
+type ListPagination struct {
+	equipmentRequestService equipment_request.EquipmentRequestService
+	perPage                 uint64
+	callbackListData        CallbackListData
+}
+
+func NewListPagination(
+	equipmentRequestService equipment_request.EquipmentRequestService,
+	perPage uint64,
+	callbackListData CallbackListData,
+) *ListPagination {
+	return &ListPagination{
+		equipmentRequestService: equipmentRequestService,
+		perPage:                 perPage,
+		callbackListData:        callbackListData,
+	}
+}
+
+func (l *ListPagination) GetMessageWithList(chatId int64) (msg tgbotapi.MessageConfig) {
+	outputMsgText := "Here all the equipment requests: \n\n"
+
+	currentPage := l.callbackListData.Page
+	count := l.equipmentRequestService.Count()
+
+	if count == 0 {
+		outputMsgText = "List with equipment requests is empty"
+		return tgbotapi.NewMessage(chatId, outputMsgText)
+	}
+
+	equipmentRequests, err := l.equipmentRequestService.List(currentPage, l.perPage)
+	if err != nil {
+		log.Printf("failed to get list of equipment requests in page %d with limit %d: %v", currentPage, l.perPage, err)
+		return tgbotapi.NewMessage(chatId, "Unable to get list of equipment requests for selected page")
+	}
+
+	for _, eq := range equipmentRequests {
+		outputMsgText += eq.String()
+		outputMsgText += "\n"
+	}
+
+	msg = tgbotapi.NewMessage(chatId, outputMsgText)
+
+	var buttons []tgbotapi.InlineKeyboardButton
+
+	if currentPage > 0 {
+		pagePrevData, _ := json.Marshal(CallbackListData{
+			Page: currentPage - 1,
+		})
+
+		pagePrev := path.CallbackPath{
+			Domain:       "business",
+			Subdomain:    "equipmentRequest",
+			CallbackName: "list",
+			CallbackData: string(pagePrevData),
+		}
+
+		buttons = append(buttons, tgbotapi.NewInlineKeyboardButtonData("Previous page", pagePrev.String()))
+	}
+
+	if (l.perPage * (currentPage + 1)) < count {
+		pageNextData, _ := json.Marshal(CallbackListData{
+			Page: currentPage + 1,
+		})
+
+		pageNext := path.CallbackPath{
+			Domain:       "business",
+			Subdomain:    "equipmentRequest",
+			CallbackName: "list",
+			CallbackData: string(pageNextData),
+		}
+
+		buttons = append(buttons, tgbotapi.NewInlineKeyboardButtonData("Next page", pageNext.String()))
+	}
+
+	if len(buttons) > 0 {
+		msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(buttons)
+	}
+
+	return msg
+}

--- a/internal/app/helpers/helpers.go
+++ b/internal/app/helpers/helpers.go
@@ -1,20 +1,5 @@
 package helpers
 
-import (
-	"log"
-	"time"
-)
-
-func DateFormatter(date string, fromLayout string, toLayout string) string {
-	parsedDate, err := time.Parse(fromLayout, date)
-	if err != nil {
-		log.Printf("fail to parse date %s: %v", date, err)
-		return date
-	}
-
-	return parsedDate.Format(toLayout)
-}
-
 func Min(x, y uint64) uint64 {
 	if x > y {
 		return y

--- a/internal/app/helpers/helpers.go
+++ b/internal/app/helpers/helpers.go
@@ -1,0 +1,23 @@
+package helpers
+
+import (
+	"log"
+	"time"
+)
+
+func DateFormatter(date string, fromLayout string, toLayout string) string {
+	parsedDate, err := time.Parse(fromLayout, date)
+	if err != nil {
+		log.Printf("fail to parse date %s: %v", date, err)
+		return date
+	}
+
+	return parsedDate.Format(toLayout)
+}
+
+func Min(x, y uint64) uint64 {
+	if x > y {
+		return y
+	}
+	return x
+}

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"github.com/ozonmp/omp-bot/internal/app/commands/business"
 	"log"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
@@ -34,6 +35,7 @@ type Router struct {
 	// storage
 	// streaming
 	// business
+	businessCommander Commander
 	// work
 	// service
 	// exchange
@@ -69,6 +71,7 @@ func NewRouter(
 		// storage
 		// streaming
 		// business
+		businessCommander: business.NewBusinessCommander(bot),
 		// work
 		// service
 		// exchange
@@ -136,6 +139,7 @@ func (c *Router) handleCallback(callback *tgbotapi.CallbackQuery) {
 	case "streaming":
 		break
 	case "business":
+		c.businessCommander.HandleCallback(callback, callbackPath)
 		break
 	case "work":
 		break
@@ -207,7 +211,7 @@ func (c *Router) handleMessage(msg *tgbotapi.Message) {
 	case "streaming":
 		break
 	case "business":
-		break
+		c.businessCommander.HandleCommand(msg, commandPath)
 	case "work":
 		break
 	case "service":

--- a/internal/model/business/models.go
+++ b/internal/model/business/models.go
@@ -2,22 +2,21 @@ package business
 
 import (
 	"fmt"
-	"github.com/ozonmp/omp-bot/internal/app/helpers"
+	"time"
 )
 
 const (
-	dataBaseDateFormat = "2006-01-02T15:04:05"
-	outputDateFormat   = "2 Jan 2006 15:04:05"
+	outputDateFormat = "2 Jan 2006 15:04:05"
 )
 
 type EquipmentRequest struct {
-	Id            uint64 `json:"-"`
-	EmployeeId    uint64 `json:"employee_id"`
-	EquipmentType string `json:"equipment_type"`
-	EquipmentId   uint64 `json:"equipment_id"`
-	CreatedAt     string `json:"created_at"`
-	DoneAt        string `json:"done_at"`
-	Status        bool   `json:"status"`
+	Id            uint64                 `json:"-"`
+	EmployeeId    uint64                 `json:"employee_id"`
+	EquipmentType string                 `json:"equipment_type"`
+	EquipmentId   uint64                 `json:"equipment_id"`
+	CreatedAt     time.Time              `json:"created_at"`
+	DoneAt        time.Time              `json:"done_at"`
+	Status        EquipmentRequestStatus `json:"status"`
 }
 
 type EquipmentRequestList struct {
@@ -25,29 +24,39 @@ type EquipmentRequestList struct {
 	List   []EquipmentRequest
 }
 
-func (equipmentRequest *EquipmentRequest) String() string {
-	createdAtDate := helpers.DateFormatter(equipmentRequest.CreatedAt, dataBaseDateFormat, outputDateFormat)
-	doneAtDate := helpers.DateFormatter(equipmentRequest.DoneAt, dataBaseDateFormat, outputDateFormat)
+type EquipmentRequestStatus int
 
-	return fmt.Sprintf("EquipmentRequest ID: %d,\nEmployee ID: %d,\nEquipment Type: %s,\nEquipment ID: %d,\nCreated at: %s,\nDone at: %s,\nStatus: %t \n",
-		equipmentRequest.Id,
-		equipmentRequest.EmployeeId,
-		equipmentRequest.EquipmentType,
-		equipmentRequest.EquipmentId,
-		createdAtDate,
-		doneAtDate,
-		equipmentRequest.Status,
+const (
+	Do EquipmentRequestStatus = iota
+	InProgress
+	Done
+	Cancelled
+)
+
+func (es EquipmentRequestStatus) String() string {
+	return [...]string{"Do", "In Progress", "Done", "Cancelled"}[es]
+}
+
+func (e *EquipmentRequest) String() string {
+	return fmt.Sprintf("EquipmentRequest ID: %d,\nEmployee ID: %d,\nEquipment Type: %s,\nEquipment ID: %d,\nCreated at: %s,\nDone at: %s,\nStatus: %s \n",
+		e.Id,
+		e.EmployeeId,
+		e.EquipmentType,
+		e.EquipmentId,
+		e.CreatedAt.Format(outputDateFormat),
+		e.DoneAt.Format(outputDateFormat),
+		e.Status,
 	)
 }
 
 var AllEquipmentRequests = EquipmentRequestList{
 	6,
 	[]EquipmentRequest{
-		{Id: 1, EmployeeId: 1, EquipmentType: "Laptop", EquipmentId: 1, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
-		{Id: 2, EmployeeId: 1, EquipmentType: "Keyboard", EquipmentId: 1, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
-		{Id: 3, EmployeeId: 1, EquipmentType: "Keyboard", EquipmentId: 1, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
-		{Id: 4, EmployeeId: 2, EquipmentType: "Laptop", EquipmentId: 2, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
-		{Id: 5, EmployeeId: 3, EquipmentType: "Keyboard", EquipmentId: 2, CreatedAt: "2021-01-19T10:00:00", DoneAt: "2021-01-19T10:00:00", Status: true},
-		{Id: 6, EmployeeId: 4, EquipmentType: "Mouse", EquipmentId: 1, CreatedAt: "2021-01-19T10:00:00", DoneAt: "2021-01-19T10:00:00", Status: true},
+		{Id: 1, EmployeeId: 1, EquipmentType: "Laptop", EquipmentId: 1, CreatedAt: time.Now(), DoneAt: time.Now(), Status: Do},
+		{Id: 2, EmployeeId: 1, EquipmentType: "Keyboard", EquipmentId: 1, CreatedAt: time.Now(), DoneAt: time.Now(), Status: InProgress},
+		{Id: 3, EmployeeId: 1, EquipmentType: "Keyboard", EquipmentId: 1, CreatedAt: time.Now(), DoneAt: time.Now(), Status: Done},
+		{Id: 4, EmployeeId: 2, EquipmentType: "Laptop", EquipmentId: 2, CreatedAt: time.Now(), DoneAt: time.Now(), Status: Cancelled},
+		{Id: 5, EmployeeId: 3, EquipmentType: "Keyboard", EquipmentId: 2, CreatedAt: time.Now(), DoneAt: time.Now(), Status: Done},
+		{Id: 6, EmployeeId: 4, EquipmentType: "Mouse", EquipmentId: 1, CreatedAt: time.Now(), DoneAt: time.Now(), Status: Do},
 	},
 }

--- a/internal/model/business/models.go
+++ b/internal/model/business/models.go
@@ -1,0 +1,53 @@
+package business
+
+import (
+	"fmt"
+	"github.com/ozonmp/omp-bot/internal/app/helpers"
+)
+
+const (
+	dataBaseDateFormat = "2006-01-02T15:04:05"
+	outputDateFormat   = "2 Jan 2006 15:04:05"
+)
+
+type EquipmentRequest struct {
+	Id            uint64 `json:"-"`
+	EmployeeId    uint64 `json:"employee_id"`
+	EquipmentType string `json:"equipment_type"`
+	EquipmentId   uint64 `json:"equipment_id"`
+	CreatedAt     string `json:"created_at"`
+	DoneAt        string `json:"done_at"`
+	Status        bool   `json:"status"`
+}
+
+type EquipmentRequestList struct {
+	LastId uint64
+	List   []EquipmentRequest
+}
+
+func (equipmentRequest *EquipmentRequest) String() string {
+	createdAtDate := helpers.DateFormatter(equipmentRequest.CreatedAt, dataBaseDateFormat, outputDateFormat)
+	doneAtDate := helpers.DateFormatter(equipmentRequest.DoneAt, dataBaseDateFormat, outputDateFormat)
+
+	return fmt.Sprintf("EquipmentRequest ID: %d,\nEmployee ID: %d,\nEquipment Type: %s,\nEquipment ID: %d,\nCreated at: %s,\nDone at: %s,\nStatus: %t \n",
+		equipmentRequest.Id,
+		equipmentRequest.EmployeeId,
+		equipmentRequest.EquipmentType,
+		equipmentRequest.EquipmentId,
+		createdAtDate,
+		doneAtDate,
+		equipmentRequest.Status,
+	)
+}
+
+var AllEquipmentRequests = EquipmentRequestList{
+	6,
+	[]EquipmentRequest{
+		{Id: 1, EmployeeId: 1, EquipmentType: "Laptop", EquipmentId: 1, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
+		{Id: 2, EmployeeId: 1, EquipmentType: "Keyboard", EquipmentId: 1, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
+		{Id: 3, EmployeeId: 1, EquipmentType: "Keyboard", EquipmentId: 1, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
+		{Id: 4, EmployeeId: 2, EquipmentType: "Laptop", EquipmentId: 2, CreatedAt: "2020-01-19T10:00:00", DoneAt: "2020-01-19T10:00:00", Status: true},
+		{Id: 5, EmployeeId: 3, EquipmentType: "Keyboard", EquipmentId: 2, CreatedAt: "2021-01-19T10:00:00", DoneAt: "2021-01-19T10:00:00", Status: true},
+		{Id: 6, EmployeeId: 4, EquipmentType: "Mouse", EquipmentId: 1, CreatedAt: "2021-01-19T10:00:00", DoneAt: "2021-01-19T10:00:00", Status: true},
+	},
+}

--- a/internal/service/business/equipment_request/service.go
+++ b/internal/service/business/equipment_request/service.go
@@ -1,0 +1,82 @@
+package equipment_request
+
+import (
+	"errors"
+	"fmt"
+	"github.com/ozonmp/omp-bot/internal/app/helpers"
+	"github.com/ozonmp/omp-bot/internal/model/business"
+)
+
+type EquipmentRequestService interface {
+	Get(equipmentRequestId uint64) (*business.EquipmentRequest, error)
+	List(page uint64, perPage uint64) ([]business.EquipmentRequest, error)
+	Create(equipmentRequest business.EquipmentRequest) (uint64, error)
+	Update(equipmentRequestId uint64, equipmentRequest business.EquipmentRequest) error
+	Remove(equipmentRequestId uint64) (bool, error)
+	Count() uint64
+}
+
+type DummyEquipmentRequestService struct{}
+
+func NewDummyEquipmentRequestService() *DummyEquipmentRequestService {
+	return &DummyEquipmentRequestService{}
+}
+
+func (s *DummyEquipmentRequestService) List(page uint64, perPage uint64) ([]business.EquipmentRequest, error) {
+	start := page * perPage
+	end := start + perPage
+	count := s.Count()
+	end = helpers.Min(end, s.Count())
+
+	if start > end || start > count {
+		return nil, errors.New(fmt.Sprintf("out of bounds with page %d and per page %d", page, perPage))
+	}
+	return business.AllEquipmentRequests.List[start:end], nil
+}
+
+func (s *DummyEquipmentRequestService) Get(equipmentRequestId uint64) (*business.EquipmentRequest, error) {
+	for i := range business.AllEquipmentRequests.List {
+		if business.AllEquipmentRequests.List[i].Id == equipmentRequestId {
+			return &business.AllEquipmentRequests.List[i], nil
+		}
+	}
+	return nil, errors.New(fmt.Sprintf("index out of range %d", equipmentRequestId))
+}
+
+func (s *DummyEquipmentRequestService) Remove(equipmentRequestId uint64) (bool, error) {
+	for i := range business.AllEquipmentRequests.List {
+		if business.AllEquipmentRequests.List[i].Id == equipmentRequestId {
+			business.AllEquipmentRequests.List = append(business.AllEquipmentRequests.List[:i], business.AllEquipmentRequests.List[i+1:]...)
+
+			return true, nil
+		}
+	}
+	return false, errors.New(fmt.Sprintf("index out of range %d", equipmentRequestId))
+}
+func (s *DummyEquipmentRequestService) Create(equipmentRequest business.EquipmentRequest) (uint64, error) {
+	itemId := business.AllEquipmentRequests.LastId + 1
+	equipmentRequest.Id = itemId
+	business.AllEquipmentRequests.List = append(business.AllEquipmentRequests.List, equipmentRequest)
+	business.AllEquipmentRequests.LastId = itemId
+	return itemId, nil
+}
+
+func (s *DummyEquipmentRequestService) Update(equipmentRequestId uint64, equipmentRequest business.EquipmentRequest) error {
+	item, err := s.Get(equipmentRequestId)
+	if err != nil {
+		return err
+	}
+
+	item.DoneAt = equipmentRequest.DoneAt
+	item.CreatedAt = equipmentRequest.CreatedAt
+	item.EquipmentId = equipmentRequest.EquipmentId
+	item.EquipmentType = equipmentRequest.EquipmentType
+	item.Status = equipmentRequest.Status
+	item.EmployeeId = equipmentRequest.EmployeeId
+
+	return nil
+}
+
+func (s *DummyEquipmentRequestService) Count() uint64 {
+	return uint64(len(business.AllEquipmentRequests.List))
+}

--- a/internal/service/business/equipment_request/service.go
+++ b/internal/service/business/equipment_request/service.go
@@ -23,15 +23,15 @@ func NewDummyEquipmentRequestService() *DummyEquipmentRequestService {
 }
 
 func (s *DummyEquipmentRequestService) List(page uint64, perPage uint64) ([]business.EquipmentRequest, error) {
-	start := page * perPage
-	end := start + perPage
+	offset := page * perPage
+	limit := offset + perPage
 	count := s.Count()
-	end = helpers.Min(end, s.Count())
+	limit = helpers.Min(limit, s.Count())
 
-	if start > end || start > count {
+	if offset > limit || offset > count {
 		return nil, errors.New(fmt.Sprintf("out of bounds with page %d and per page %d", page, perPage))
 	}
-	return business.AllEquipmentRequests.List[start:end], nil
+	return business.AllEquipmentRequests.List[offset:limit], nil
 }
 
 func (s *DummyEquipmentRequestService) Get(equipmentRequestId uint64) (*business.EquipmentRequest, error) {

--- a/internal/service/business/equipment_request/service.go
+++ b/internal/service/business/equipment_request/service.go
@@ -35,12 +35,7 @@ func (s *DummyEquipmentRequestService) List(page uint64, perPage uint64) ([]busi
 }
 
 func (s *DummyEquipmentRequestService) Get(equipmentRequestId uint64) (*business.EquipmentRequest, error) {
-	for i := range business.AllEquipmentRequests.List {
-		if business.AllEquipmentRequests.List[i].Id == equipmentRequestId {
-			return &business.AllEquipmentRequests.List[i], nil
-		}
-	}
-	return nil, errors.New(fmt.Sprintf("index out of range %d", equipmentRequestId))
+	return s.get(equipmentRequestId)
 }
 
 func (s *DummyEquipmentRequestService) Remove(equipmentRequestId uint64) (bool, error) {
@@ -62,7 +57,7 @@ func (s *DummyEquipmentRequestService) Create(equipmentRequest business.Equipmen
 }
 
 func (s *DummyEquipmentRequestService) Update(equipmentRequestId uint64, equipmentRequest business.EquipmentRequest) error {
-	item, err := s.Get(equipmentRequestId)
+	item, err := s.get(equipmentRequestId)
 	if err != nil {
 		return err
 	}
@@ -79,4 +74,13 @@ func (s *DummyEquipmentRequestService) Update(equipmentRequestId uint64, equipme
 
 func (s *DummyEquipmentRequestService) Count() uint64 {
 	return uint64(len(business.AllEquipmentRequests.List))
+}
+
+func (s *DummyEquipmentRequestService) get(equipmentRequestId uint64) (*business.EquipmentRequest, error) {
+	for i := range business.AllEquipmentRequests.List {
+		if business.AllEquipmentRequests.List[i].Id == equipmentRequestId {
+			return &business.AllEquipmentRequests.List[i], nil
+		}
+	}
+	return nil, errors.New(fmt.Sprintf("index out of range %d", equipmentRequestId))
 }


### PR DESCRIPTION
Created commands:

/help__business__equipmentRequest - help
/list__business__equipmentRequest - list of all equipment requests
/get__business__equipmentRequest {id} - get one equipment request by id
/new__business__equipmentRequest {json} - create a new one equipment request by json
/edit__business__equipmentRequest {id} {json} - update existing equipment request by id
/remove__business__equipmentRequest {id} - remove one equipment request by id

Json data example:
 {"employee_id":12, "equipment_type":"Laptop", "equipment_id":15, "created_at":"2020-10-12T16:04:05Z", "done_at":"2020-10-12T16:04:05Z", "status":false}
